### PR TITLE
Made compatible with latest Deno

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 on: push
-name: deno@v0.36.0
+name: deno@v1.0.0-rc2
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        deno: ['v0.36.0']
+        deno: ['v1.0.0-rc2']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     name: Deno ${{ matrix.deno }} test in ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `cursor`
 
-![deno@v0.36.0](https://github.com/iAmNathanJ/cursor/workflows/deno@v0.36.0/badge.svg)
+![deno@v1.0.0-rc2](https://github.com/iAmNathanJ/cursor/workflows/deno@v1.0.0-rc2/badge.svg)
 
 ANSI escape sequences to control the cursor in a terminal.
 

--- a/cursor.ts
+++ b/cursor.ts
@@ -1,6 +1,6 @@
 import { encode } from "./deps.ts";
 
-const isTerminalApp = Deno.env("TERM_PROGRAM") === "Apple_Terminal";
+const isTerminalApp = Deno.env.get("TERM_PROGRAM") === "Apple_Terminal";
 
 const ESC = "\u001B[";
 

--- a/dev-deps.ts
+++ b/dev-deps.ts
@@ -1,3 +1,3 @@
 export {
   assertEquals
-} from "https://deno.land/std@v0.36.0/testing/asserts.ts";
+} from "https://deno.land/std@0.50.0/testing/asserts.ts"


### PR DESCRIPTION
Simple fix, updated Deno.env call to Deno.env.get to match the current version.